### PR TITLE
Rename variable to align with Angular Naming conventions for observables

### DIFF
--- a/Angular/src/app/language-list/language-list.component.html
+++ b/Angular/src/app/language-list/language-list.component.html
@@ -1,7 +1,7 @@
 <h1>Language List</h1>
 
 <ul>
-  <li *ngFor="let language of languages">
+  <li *ngFor="let language of languages$">
     <a routerLink="/language/{{language.language_id}}">{{ language.language_name }}</a>
 
     <!-- <ul>

--- a/Angular/src/app/language-list/language-list.component.ts
+++ b/Angular/src/app/language-list/language-list.component.ts
@@ -8,7 +8,7 @@ import { Observable } from 'rxjs';
   styleUrls: ['./language-list.component.scss']
 })
 export class LanguageListComponent implements OnInit {
-  languages: Object;
+  languages$: Object;
 
   constructor(private data: DataService) {}
 
@@ -16,7 +16,7 @@ export class LanguageListComponent implements OnInit {
     // Actually, we won't override the data from API but now we just need some mock data to display
     this.data.getLanguageList().subscribe(
       data =>
-        (this.languages = [
+        (this.languages$ = [
           {
             language_id: 'en_US',
             language_name: 'English'


### PR DESCRIPTION
Angular Naming conventions for observables: https://angular.io/guide/rx-library#naming-conventions-for-observables